### PR TITLE
Fix chat interface layout to match preview pane height

### DIFF
--- a/assets/css/ai-copilot.css
+++ b/assets/css/ai-copilot.css
@@ -135,6 +135,8 @@
   flex-direction: column;
   box-shadow: var(--mpcc-shadow-md);
   transition: var(--mpcc-transition-base);
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* ==========================================================================
@@ -406,6 +408,7 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  height: 100%;
 }
 
 .mpcc-chat-messages {
@@ -657,6 +660,7 @@
   padding: var(--mpcc-spacing-xl);
   background: var(--mpcc-bg-secondary);
   border-top: 1px solid var(--mpcc-border-secondary);
+  flex-shrink: 0;
 }
 
 .mpcc-chat-input-wrapper {

--- a/assets/css/courses-integration.css
+++ b/assets/css/courses-integration.css
@@ -56,6 +56,8 @@
     max-width: 1600px;
     height: 92%;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
 }
 
 /* Modal Header */
@@ -68,6 +70,7 @@
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     border-radius: 8px 8px 0 0;
+    flex-shrink: 0;
 }
 
 #mpcc-ai-modal .modal-header h2 {
@@ -108,23 +111,41 @@
 
 #mpcc-ai-interface-container {
     flex: 1;
-    height: 100%;
+    min-height: 0;
     border-right: 1px solid #ddd;
     display: flex;
     flex-direction: column;
     background: #ffffff;
+    overflow: hidden;
 }
 
 #mpcc-preview-pane {
     flex: 1;
-    height: 100%;
+    min-height: 0;
     background: #f8f9fa;
-    overflow-y: auto;
     display: none;
+    flex-direction: column;
 }
 
 #mpcc-preview-pane.active {
-    display: block;
+    display: flex;
+}
+
+/* Ensure proper flex layout for chat interface */
+#mpcc-ai-interface-container .mpcc-ai-interface {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+#mpcc-ai-interface-container .mpcc-chat-messages {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+}
+
+#mpcc-ai-interface-container .mpcc-chat-input-container {
+    flex-shrink: 0;
 }
 
 /* Loading State */
@@ -139,6 +160,32 @@
 .mpcc-loading-container .spinner {
     float: none;
     margin: 0 auto 20px;
+}
+
+/* Chat interface specific styles within modal */
+#mpcc-ai-modal .mpcc-chat-messages {
+    padding: 20px;
+    background: #ffffff;
+    border-radius: 0;
+    border: none;
+    margin-bottom: 0;
+}
+
+#mpcc-ai-modal .mpcc-chat-input-container {
+    padding: 20px;
+    background: #f8f9fa;
+    border-top: 1px solid #e0e0e0;
+}
+
+#mpcc-ai-modal .mpcc-chat-input-wrapper textarea {
+    background: #ffffff;
+    border: 2px solid #e0e0e0;
+    transition: all 0.3s ease;
+}
+
+#mpcc-ai-modal .mpcc-chat-input-wrapper textarea:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
 }
 
 /* ==========================================================================

--- a/src/MemberPressCoursesCopilot/Services/CourseIntegrationService.php
+++ b/src/MemberPressCoursesCopilot/Services/CourseIntegrationService.php
@@ -129,22 +129,24 @@ class CourseIntegrationService extends BaseService
                                 '<h2 style="margin: 0; color: white;"><?php echo esc_js(__('Create Course with AI Assistant', 'memberpress-courses-copilot')); ?></h2>' +
                                 '<span id="mpcc-close-modal" style="cursor: pointer; font-size: 24px; font-weight: bold; color: white;">&times;</span>' +
                             '</div>' +
-                            '<div style="display: flex; flex: 1; overflow: hidden;">' +
-                                '<div id="mpcc-ai-interface-container" style="flex: 1; height: 100%; border-right: 1px solid #ddd; display: flex; flex-direction: column;">' +
-                                    '<div style="display: flex; justify-content: center; align-items: center; height: 100%; color: #666;">' +
+                            '<div style="display: flex; flex: 1; overflow: hidden; height: calc(100% - 71px);">' +
+                                '<div id="mpcc-ai-interface-container" style="flex: 1; min-height: 0; border-right: 1px solid #ddd; display: flex; flex-direction: column; overflow: hidden;">' +
+                                    '<div style="display: flex; justify-content: center; align-items: center; flex: 1; color: #666;">' +
                                         '<div style="text-align: center;">' +
                                             '<div class="spinner is-active" style="float: none; margin: 0 auto 20px;"></div>' +
                                             '<p><?php echo esc_js(__('Loading AI Assistant...', 'memberpress-courses-copilot')); ?></p>' +
                                         '</div>' +
                                     '</div>' +
                                 '</div>' +
-                                '<div id="mpcc-preview-pane" style="flex: 1; height: 100%; background: #f8f9fa; overflow-y: auto; display: none;">' +
-                                    '<div style="padding: 20px;">' +
-                                        '<h3 style="margin: 0 0 20px 0; color: #333;"><?php echo esc_js(__('Course Preview', 'memberpress-courses-copilot')); ?></h3>' +
-                                        '<div id="mpcc-preview-content">' +
-                                            '<p style="color: #666; text-align: center; padding: 40px;"><?php echo esc_js(__('Course preview will appear here as you build it...', 'memberpress-courses-copilot')); ?></p>' +
+                                '<div id="mpcc-preview-pane" style="flex: 1; min-height: 0; background: #f8f9fa; display: none; flex-direction: column;">' +
+                                    '<div style="flex: 1; overflow-y: auto; display: flex; flex-direction: column;">' +
+                                        '<div style="padding: 20px; flex: 1;">' +
+                                            '<h3 style="margin: 0 0 20px 0; color: #333;"><?php echo esc_js(__('Course Preview', 'memberpress-courses-copilot')); ?></h3>' +
+                                            '<div id="mpcc-preview-content">' +
+                                                '<p style="color: #666; text-align: center; padding: 40px;"><?php echo esc_js(__('Course preview will appear here as you build it...', 'memberpress-courses-copilot')); ?></p>' +
+                                            '</div>' +
                                         '</div>' +
-                                        '<div style="padding: 20px; border-top: 1px solid #ddd; display: flex; gap: 10px; justify-content: flex-end;">' +
+                                        '<div style="padding: 20px; border-top: 1px solid #ddd; display: flex; gap: 10px; justify-content: flex-end; background: #f8f9fa;">' +
                                             '<button id="mpcc-save-draft" class="button" disabled><?php echo esc_js(__('Save Draft', 'memberpress-courses-copilot')); ?></button>' +
                                             '<button id="mpcc-create-course" class="button button-primary" disabled><?php echo esc_js(__('Create Course', 'memberpress-courses-copilot')); ?></button>' +
                                         '</div>' +
@@ -177,7 +179,7 @@ class CourseIntegrationService extends BaseService
                     success: function(response) {
                         if (response.success) {
                             $('#mpcc-ai-interface-container').html(response.data.html);
-                            $('#mpcc-preview-pane').addClass('active').show(); // Show the preview pane
+                            $('#mpcc-preview-pane').addClass('active').css('display', 'flex'); // Show the preview pane with flex display
                         } else {
                             $('#mpcc-ai-interface-container').html('<div style="padding: 20px; text-align: center; color: #d63638;"><p>' + (response.data || '<?php echo esc_js(__('Failed to load AI interface', 'memberpress-courses-copilot')); ?>') + '</p></div>');
                         }
@@ -512,7 +514,7 @@ class CourseIntegrationService extends BaseService
             // Fallback basic interface
             ?>
             <div id="mpcc-ai-chat-interface" class="mpcc-ai-interface" data-context="<?php echo esc_attr($context); ?>" data-post-id="<?php echo esc_attr($post_id); ?>" style="height: 100%; display: flex; flex-direction: column;">
-                <div class="mpcc-chat-messages" style="flex: 1; overflow-y: auto; border: none; padding: 20px; background: white;">
+                <div class="mpcc-chat-messages" style="flex: 1; min-height: 0; overflow-y: auto; border: none; padding: 20px; background: white;">
                     <div class="mpcc-welcome-message" style="padding: 20px; text-align: center; color: #666;">
                         <div style="font-size: 48px; margin-bottom: 15px;">🤖</div>
                         <h3 style="margin: 0 0 10px 0;"><?php esc_html_e('AI Course Assistant', 'memberpress-courses-copilot'); ?></h3>

--- a/templates/ai-chat-interface.php
+++ b/templates/ai-chat-interface.php
@@ -14,8 +14,8 @@ $post_id = $post_id ?? 0;
 ?>
 
 <input type="hidden" id="mpcc-ajax-nonce" value="<?php echo wp_create_nonce('mpcc_courses_integration'); ?>" />
-<div id="mpcc-ai-chat-interface" class="mpcc-ai-interface" data-context="<?php echo esc_attr($context); ?>" data-post-id="<?php echo esc_attr($post_id); ?>">
-    <div id="mpcc-chat-messages" class="mpcc-chat-messages" style="height: <?php echo $context === 'course_creation' ? '400px' : '300px'; ?>; overflow-y: auto; border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; background: #f8f9fa; border-radius: 8px;">
+<div id="mpcc-ai-chat-interface" class="mpcc-ai-interface" data-context="<?php echo esc_attr($context); ?>" data-post-id="<?php echo esc_attr($post_id); ?>" style="height: 100%; display: flex; flex-direction: column;">
+    <div id="mpcc-chat-messages" class="mpcc-chat-messages" style="flex: 1; min-height: 0; overflow-y: auto; border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; background: #f8f9fa; border-radius: 8px;">
         <!-- Welcome message will be replaced by conversation history if a session exists -->
         <div class="mpcc-welcome-message" style="text-align: center; padding: 20px; color: #666;">
             <div style="font-size: 32px; margin-bottom: 15px;">🤖</div>


### PR DESCRIPTION
- Update modal structure to use proper flexbox layout
- Remove fixed heights (400px/300px) from chat messages area
- Make both columns expand to full available height
- Add proper overflow handling for scrollable content
- Fix preview pane display to use flex when active
- Ensure chat input stays at bottom of column
- Add min-height: 0 to flex children for proper sizing
- Update CSS for better responsive layout

The chat interface now properly expands vertically to match the preview pane, creating a balanced two-column layout.

🤖 Generated with [Claude Code](https://claude.ai/code)