### PR TITLE
Fix chat interface vertical height issue properly (#17)

### DIFF
--- a/assets/css/ai-copilot.css
+++ b/assets/css/ai-copilot.css
@@ -336,6 +336,22 @@
   line-height: 1.5;
 }
 
+/* Ensure proper flex layout for AI interface in modal */
+#mpcc-ai-interface-container {
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
+/* Ensure the parent div of the AI interface uses full height */
+#mpcc-ai-chat-interface {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
 /* Template Selection */
 .mpcc-templates-section {
   padding: var(--mpcc-spacing-xl);
@@ -444,8 +460,54 @@
   background: var(--mpcc-bg-chat);
   scrollbar-width: thin;
   scrollbar-color: var(--mpcc-border-secondary) transparent;
-  min-height: 400px;
-  max-height: calc(100vh - 350px);
+  min-height: 0;
+  border: 1px solid var(--mpcc-border-secondary);
+  border-radius: var(--mpcc-radius-md);
+  /* Remove max-height constraint to allow full height usage */
+}
+
+/* Ensure chat messages uses full available height when in modal */
+#mpcc-ai-interface-container .mpcc-chat-messages {
+  height: 0; /* Force flex to calculate height */
+  flex: 1 1 auto;
+}
+
+/* Ensure the AI interface uses full height in modal */
+#mpcc-ai-interface-container {
+  display: flex !important;
+  flex-direction: column !important;
+  height: 100% !important;
+}
+
+#mpcc-ai-interface-container .mpcc-ai-interface {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+/* Override inline styles on chat messages when in modal */
+#mpcc-ai-interface-container .mpcc-chat-messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 0; /* Force flexbox to calculate height */
+  margin-bottom: 0;
+}
+
+/* Ensure chat interface fills available space properly */
+#mpcc-ai-interface-container .mpcc-chat-interface {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 0; /* Force flexbox to calculate height */
+}
+
+/* Session controls and input should not grow */
+#mpcc-ai-interface-container .mpcc-session-controls,
+#mpcc-ai-interface-container .mpcc-chat-input-container {
+  flex: 0 0 auto;
 }
 
 .mpcc-chat-messages::-webkit-scrollbar {
@@ -698,6 +760,11 @@
   background: var(--mpcc-bg-secondary);
   border-top: 1px solid var(--mpcc-border-secondary);
   flex-shrink: 0;
+}
+
+/* Compact input container in modal to maximize message area */
+#mpcc-ai-interface-container .mpcc-chat-input-container {
+  padding: var(--mpcc-spacing-lg) var(--mpcc-spacing-xl);
 }
 
 .mpcc-chat-input-wrapper {
@@ -1734,9 +1801,46 @@
   display: flex;
   gap: var(--mpcc-spacing-md);
   justify-content: center;
-  padding: var(--mpcc-spacing-lg) 0;
+  padding: var(--mpcc-spacing-lg);
   background: var(--mpcc-bg-secondary);
   border-top: 1px solid var(--mpcc-border-secondary);
+  flex-shrink: 0; /* Prevent shrinking */
+}
+
+/* Ensure session controls are always visible */
+.mpcc-session-controls {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+/* Fix chat messages to use full available height in modal */
+#mpcc-ai-interface-container {
+  height: 100% !important;
+  overflow: visible !important;
+}
+
+#mpcc-ai-interface-container .mpcc-ai-interface {
+  height: 100% !important;
+  display: flex !important;
+  flex-direction: column !important;
+  overflow: visible !important;
+}
+
+#mpcc-ai-interface-container .mpcc-chat-messages {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
+  max-height: none !important;
+}
+
+#mpcc-ai-interface-container .mpcc-chat-input-container {
+  flex-shrink: 0 !important;
+}
+
+#mpcc-ai-interface-container .mpcc-session-controls {
+  flex-shrink: 0 !important;
 }
 
 .mpcc-session-controls button {
@@ -1777,6 +1881,30 @@
   padding: var(--mpcc-spacing-lg);
   max-height: 300px;
   overflow-y: auto;
+}
+
+/* Fix layout when session controls are placed after input container */
+.mpcc-ai-interface {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Ensure chat messages fills available space */
+.mpcc-ai-interface > .mpcc-chat-messages {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* Input container should not grow */
+.mpcc-ai-interface > .mpcc-chat-input-container {
+  flex: 0 0 auto;
+}
+
+/* Session controls should not grow */
+.mpcc-ai-interface > .mpcc-session-controls {
+  flex: 0 0 auto;
 }
 
 /* Print styles */

--- a/assets/js/simple-ai-chat.js
+++ b/assets/js/simple-ai-chat.js
@@ -547,7 +547,7 @@ jQuery(document).ready(function($) {
         // Add session management button
         if (!$('#mpcc-session-manager-btn').length) {
             const sessionControls = `
-                <div class="mpcc-session-controls" style="margin-bottom: 10px;">
+                <div class="mpcc-session-controls">
                     <button id="mpcc-session-manager-btn" class="button button-small">
                         <span class="dashicons dashicons-list-view"></span> Previous Conversations
                     </button>
@@ -558,6 +558,9 @@ jQuery(document).ready(function($) {
                 <div id="mpcc-session-list" style="display: none;"></div>
             `;
             $('#mpcc-chat-input-container').after(sessionControls);
+            
+            // Add class to indicate session controls are present
+            $('#mpcc-ai-interface-container').addClass('has-session-controls');
             
             // Bind events
             $('#mpcc-session-manager-btn').on('click', function() {

--- a/src/MemberPressCoursesCopilot/Services/CourseIntegrationService.php
+++ b/src/MemberPressCoursesCopilot/Services/CourseIntegrationService.php
@@ -129,8 +129,8 @@ class CourseIntegrationService extends BaseService
                                 '<h2 style="margin: 0; color: white;"><?php echo esc_js(__('Create Course with AI Assistant', 'memberpress-courses-copilot')); ?></h2>' +
                                 '<span id="mpcc-close-modal" style="cursor: pointer; font-size: 24px; font-weight: bold; color: white;">&times;</span>' +
                             '</div>' +
-                            '<div style="display: flex; flex: 1; overflow: hidden; height: calc(100% - 71px);">' +
-                                '<div id="mpcc-ai-interface-container" style="flex: 1; min-height: 0; border-right: 1px solid #ddd; display: flex; flex-direction: column; overflow: hidden;">' +
+                            '<div style="display: flex; flex: 1; height: calc(100% - 71px);">' +
+                                '<div id="mpcc-ai-interface-container" style="flex: 1; min-height: 0; border-right: 1px solid #ddd; display: flex; flex-direction: column;">' +
                                     '<div style="display: flex; justify-content: center; align-items: center; flex: 1; color: #666;">' +
                                         '<div style="text-align: center;">' +
                                             '<div class="spinner is-active" style="float: none; margin: 0 auto 20px;"></div>' +

--- a/templates/ai-chat-interface.php
+++ b/templates/ai-chat-interface.php
@@ -14,8 +14,8 @@ $post_id = $post_id ?? 0;
 ?>
 
 <input type="hidden" id="mpcc-ajax-nonce" value="<?php echo wp_create_nonce('mpcc_courses_integration'); ?>" />
-<div id="mpcc-ai-chat-interface" class="mpcc-ai-interface" data-context="<?php echo esc_attr($context); ?>" data-post-id="<?php echo esc_attr($post_id); ?>" style="height: 100%; display: flex; flex-direction: column;">
-    <div id="mpcc-chat-messages" class="mpcc-chat-messages" style="flex: 1; min-height: 0; overflow-y: auto; border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; background: #f8f9fa; border-radius: 8px;">
+<div id="mpcc-ai-chat-interface" class="mpcc-ai-interface" data-context="<?php echo esc_attr($context); ?>" data-post-id="<?php echo esc_attr($post_id); ?>">
+    <div id="mpcc-chat-messages" class="mpcc-chat-messages">
         <!-- Welcome message will be replaced by conversation history if a session exists -->
         <div class="mpcc-welcome-message" style="text-align: center; padding: 20px; color: #666;">
             <div style="font-size: 32px; margin-bottom: 15px;">🤖</div>


### PR DESCRIPTION
- Remove overflow: hidden from modal container inline styles
- Allow proper scrolling in chat messages area
- Ensure session controls remain visible at bottom
- Add flex-shrink: 0 to input and session controls
- Set overflow: visible on containers to prevent clipping
- Remove max-height constraint on chat messages

The chat messages area now properly expands to use all available vertical space while keeping buttons visible and functional.

🤖 Generated with [Claude Code](https://claude.ai/code)