### PR TITLE
Fix lesson content generation to use plain text instead of HTML

### DIFF
--- a/assets/js/course-preview-editor.js
+++ b/assets/js/course-preview-editor.js
@@ -157,7 +157,7 @@
                             <span class="mpcc-save-indicator"></span>
                         </div>
                     </div>
-                    <textarea class="mpcc-editor-textarea" rows="10" placeholder="Enter lesson content...">${this.escapeHtml(content)}</textarea>
+                    <textarea class="mpcc-editor-textarea" rows="10" placeholder="Enter lesson content...">${content}</textarea>
                     <div class="mpcc-editor-actions">
                         <button type="button" class="button button-primary button-small mpcc-editor-save">Save</button>
                         <button type="button" class="button button-small mpcc-editor-cancel">Cancel</button>

--- a/src/MemberPressCoursesCopilot/Controllers/AjaxController.php
+++ b/src/MemberPressCoursesCopilot/Controllers/AjaxController.php
@@ -2270,7 +2270,7 @@ class AjaxController extends BaseController
         $sessionId = $this->sanitizeInput($_POST['session_id'] ?? '');
         $sectionId = $this->sanitizeInput($_POST['section_id'] ?? '');
         $lessonId = $this->sanitizeInput($_POST['lesson_id'] ?? '');
-        $content = wp_kses_post($_POST['content'] ?? '');
+        $content = sanitize_textarea_field($_POST['content'] ?? '');
         
         if (empty($sessionId) || empty($sectionId) || empty($lessonId)) {
             throw new \Exception('Session ID, section ID, and lesson ID are required');

--- a/src/MemberPressCoursesCopilot/Controllers/SimpleAjaxController.php
+++ b/src/MemberPressCoursesCopilot/Controllers/SimpleAjaxController.php
@@ -334,7 +334,7 @@ class SimpleAjaxController
             $sessionId = sanitize_text_field($_POST['session_id'] ?? '');
             $lessonId = sanitize_text_field($_POST['lesson_id'] ?? '');
             $lessonTitle = sanitize_text_field($_POST['lesson_title'] ?? '');
-            $content = wp_kses_post($_POST['content'] ?? '');
+            $content = sanitize_textarea_field($_POST['content'] ?? '');
             
             if (empty($lessonId) || empty($sessionId)) {
                 throw new \Exception('Lesson ID and Session ID are required');

--- a/src/MemberPressCoursesCopilot/Services/CourseAjaxService.php
+++ b/src/MemberPressCoursesCopilot/Services/CourseAjaxService.php
@@ -1047,7 +1047,7 @@ Example: If a user says they want to create a PHP course for people with HTML/CS
         $sessionId = sanitize_text_field($_POST['session_id'] ?? '');
         $sectionId = sanitize_text_field($_POST['section_id'] ?? '');
         $lessonId = sanitize_text_field($_POST['lesson_id'] ?? '');
-        $content = wp_kses_post($_POST['content'] ?? '');
+        $content = sanitize_textarea_field($_POST['content'] ?? '');
         $orderIndex = isset($_POST['order_index']) ? (int) $_POST['order_index'] : 0;
         
         if (empty($sessionId) || empty($sectionId) || empty($lessonId)) {
@@ -1596,8 +1596,10 @@ Example: If a user says they want to create a PHP course for people with HTML/CS
         $prompt .= "2. Explains concepts with examples\n";
         $prompt .= "3. Includes practical applications\n";
         $prompt .= "4. Summarizes key points\n";
-        $prompt .= "5. Uses appropriate HTML formatting (h2, h3, p, ul, ol, etc.)\n\n";
-        $prompt .= "Format the content in HTML suitable for display in a learning management system.";
+        $prompt .= "5. Uses clear formatting with proper headings, paragraphs, and lists\n\n";
+        $prompt .= "Format the content as clean, readable plain text with proper spacing and structure. ";
+        $prompt .= "Use line breaks between sections, bullet points for lists, and clear headings. ";
+        $prompt .= "Do NOT use HTML tags or markdown - just plain, well-formatted text.";
         
         return $prompt;
     }


### PR DESCRIPTION
- Change AI prompts to generate plain text with proper formatting instead of HTML
- Update content sanitization from wp_kses_post() to sanitize_textarea_field()
- Remove HTML beautification code that was added but not needed
- Explicitly instruct AI to avoid HTML tags and markdown
- Update all controllers to handle plain text content

Now lesson content is generated as readable, well-formatted plain text suitable for course curriculum editing, rather than raw HTML code.

🤖 Generated with [Claude Code](https://claude.ai/code)