### PR TITLE
Fix issue #51: Remove editing for published courses and add duplicate…

### DIFF
--- a/assets/css/course-editor-page.css
+++ b/assets/css/course-editor-page.css
@@ -455,6 +455,17 @@
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
 
+#mpcc-view-course, #mpcc-duplicate-course {
+    background: #f0f0f1;
+    border: 1px solid #dcdcde;
+    color: #1d2327;
+}
+
+#mpcc-view-course:hover, #mpcc-duplicate-course:hover {
+    background: #e0e0e0;
+    transform: translateY(-1px);
+}
+
 /* Course header styles */
 .mpcc-course-header {
     margin-bottom: 24px;
@@ -475,6 +486,27 @@
     color: #646970;
     font-size: 16px;
     line-height: 1.5;
+}
+
+.mpcc-course-locked-notice {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+    border: 1px solid #ffeaa7;
+    border-radius: 8px;
+    color: #856404;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.mpcc-course-locked-notice .dashicons {
+    color: #856404;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
 }
 
 .mpcc-course-title-row {
@@ -520,6 +552,11 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     overflow: hidden;
     transition: box-shadow 0.2s;
+}
+
+.mpcc-section.mpcc-section-locked {
+    background: #f9f9f9;
+    border: 1px solid #e0e0e0;
 }
 
 .mpcc-section:hover {
@@ -592,6 +629,29 @@
     width: 4px;
     background: #00a32a;
     border-radius: 8px 0 0 8px;
+}
+
+.mpcc-lesson-item.mpcc-lesson-locked {
+    background: #f9f9f9;
+    border: 1px solid #e0e0e0;
+    cursor: default;
+}
+
+.mpcc-lesson-item.mpcc-lesson-locked:hover {
+    transform: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.mpcc-lesson-lock-icon {
+    color: #646970;
+    display: flex;
+    align-items: center;
+}
+
+.mpcc-lesson-lock-icon .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
 }
 
 .mpcc-lesson-info {

--- a/src/MemberPressCoursesCopilot/Admin/CourseEditorPage.php
+++ b/src/MemberPressCoursesCopilot/Admin/CourseEditorPage.php
@@ -251,6 +251,10 @@ class CourseEditorPage
                                     <span class="dashicons dashicons-external"></span>
                                     <?php echo esc_html__('View Course', 'memberpress-courses-copilot'); ?>
                                 </button>
+                                <button type="button" id="mpcc-duplicate-course" style="display: none;">
+                                    <span class="dashicons dashicons-admin-page"></span>
+                                    <?php echo esc_html__('Duplicate Course', 'memberpress-courses-copilot'); ?>
+                                </button>
                                 <button type="button" id="mpcc-create-course" disabled>
                                     <span class="dashicons dashicons-yes"></span>
                                     <?php echo esc_html__('Create Course', 'memberpress-courses-copilot'); ?>

--- a/src/MemberPressCoursesCopilot/Services/LessonDraftService.php
+++ b/src/MemberPressCoursesCopilot/Services/LessonDraftService.php
@@ -262,4 +262,42 @@ class LessonDraftService {
         
         return $course_structure;
     }
+    
+    /**
+     * Copy all lesson drafts from one session to another
+     */
+    public function copySessionDrafts($sourceSessionId, $targetSessionId) {
+        global $wpdb;
+        
+        $table_name = $this->table->getTableName();
+        
+        // Get all drafts from the source session
+        $sourceDrafts = $this->getSessionDrafts($sourceSessionId);
+        
+        if (empty($sourceDrafts)) {
+            error_log('MPCC: No drafts found to copy from session: ' . $sourceSessionId);
+            return 0;
+        }
+        
+        $copiedCount = 0;
+        
+        // Copy each draft to the target session
+        foreach ($sourceDrafts as $draft) {
+            $result = $this->saveDraft(
+                $targetSessionId,
+                $draft->section_id,
+                $draft->lesson_id,
+                $draft->content,
+                $draft->order_index
+            );
+            
+            if ($result) {
+                $copiedCount++;
+            }
+        }
+        
+        error_log('MPCC: Copied ' . $copiedCount . ' lesson drafts from session ' . $sourceSessionId . ' to session ' . $targetSessionId);
+        
+        return $copiedCount;
+    }
 }


### PR DESCRIPTION
… functionality

Phase 1 - Disable Editing for Published Courses:
- Hide lesson edit buttons (pencil icons) when course is published
- Remove section editing capabilities (edit/delete buttons)
- Block AI content generation with warning messages
- Add visual locked state with prominent warning banner
- Show lock icons and tooltips explaining editing is disabled
- Add CSS styling for locked sections and lessons
- Toast notifications explain why actions are blocked

Phase 2 - Add Duplicate Functionality:
- Added "Duplicate Course" button alongside existing action buttons
- Button only appears for published courses
- Creates new conversation session with duplicated course structure
- Preserves all generated lesson content via copySessionDrafts()
- Duplicated course is in draft state (unpublished)
- Title marked with "(Draft Copy)" suffix for clear differentiation
- Added handleDuplicateCourse AJAX handler in SimpleAjaxController
- Added copySessionDrafts method in LessonDraftService
- Seamless redirect to new session for editing
- Consistent button styling and user experience

Complete workflow:
1. Published courses are locked and cannot be edited
2. Users can duplicate published courses to create editable drafts
3. All lesson content is preserved in the duplicate
4. Users can freely edit the duplicated draft version

Closes #51

🤖 Generated with [Claude Code](https://claude.ai/code)