### PR TITLE
Fix published state bug by disabling chat for published courses

### DIFF
--- a/assets/css/course-editor-page.css
+++ b/assets/css/course-editor-page.css
@@ -280,6 +280,19 @@
     border-color: #667eea;
 }
 
+/* Disabled state for chat input */
+.mpcc-chat-input:disabled {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+    opacity: 0.7;
+    border-color: #dcdcde;
+}
+
+.mpcc-chat-input:disabled::placeholder {
+    color: #646970;
+    font-style: italic;
+}
+
 #mpcc-send-message {
     margin-top: 10px;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -295,6 +308,40 @@
 #mpcc-send-message:hover {
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+#mpcc-send-message:disabled {
+    background: #dcdcde;
+    cursor: not-allowed;
+    opacity: 0.5;
+    transform: none;
+}
+
+#mpcc-send-message:disabled:hover {
+    transform: none;
+    box-shadow: none;
+}
+
+/* Chat disabled notice */
+.mpcc-chat-disabled-notice {
+    background: #fff8dc;
+    border: 1px solid #f0e6c0;
+    padding: 12px 16px;
+    margin-bottom: 15px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #646970;
+}
+
+.mpcc-chat-disabled-notice .dashicons {
+    color: #dba617;
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
 }
 
 /* Chat messages */

--- a/assets/js/course-editor-page.js
+++ b/assets/js/course-editor-page.js
@@ -402,6 +402,38 @@
             // Update view course button visibility and functionality
             this.updateViewCourseButton();
             
+            // Disable chat for published courses
+            if (this.publishedCourseId) {
+                // Disable chat input and send button
+                $('#mpcc-chat-input').prop('disabled', true)
+                    .attr('placeholder', 'This course has been published. Use "Duplicate Course" to create a new version.');
+                $('#mpcc-send-message').prop('disabled', true);
+                
+                // Hide quick starter suggestions
+                $('#mpcc-quick-starter-suggestions').hide();
+                
+                // Add info message if not already present
+                if (!$('.mpcc-chat-disabled-notice').length) {
+                    $('.mpcc-chat-input-wrapper').prepend(
+                        '<div class="mpcc-chat-disabled-notice">' +
+                        '<span class="dashicons dashicons-info"></span> ' +
+                        'This course is published and locked. To make changes, use the "Duplicate Course" button above.' +
+                        '</div>'
+                    );
+                }
+            } else {
+                // Re-enable chat for draft courses
+                $('#mpcc-chat-input').prop('disabled', false)
+                    .attr('placeholder', 'Type a message...');
+                $('#mpcc-send-message').prop('disabled', false);
+                
+                // Show quick starter suggestions
+                $('#mpcc-quick-starter-suggestions').show();
+                
+                // Remove disabled notice
+                $('.mpcc-chat-disabled-notice').remove();
+            }
+            
         },
         
         renderSection: function(section, sectionIndex) {


### PR DESCRIPTION
Implemented solution to prevent AI chat editing for published courses as per Issue #59.

Changes:
- Disable chat input and send button when viewing published courses
- Show helpful notice explaining the course is locked
- Hide quick starter suggestions for published courses
- Add visual styling for disabled state (grayed out inputs)
- Re-enable chat interface for draft courses
- Users must use "Duplicate Course" button to create editable version

This ensures published courses remain locked and prevents confusion where new courses would incorrectly show as published. Fixes #59

🤖 Generated with [Claude Code](https://claude.ai/code)